### PR TITLE
Overwrite &mt to tap-preferred

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -9,6 +9,14 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 
+&mt {
+	tapping-term-ms = <400>;
+};
+
+&lt {
+	quick-tap-ms = <150>;
+};
+
 / {
 	keymap {
 		compatible = "zmk,keymap";
@@ -53,12 +61,4 @@
             >;
          };
 	};
-};
-
-&mt {
-	tapping-term-ms = <400>;
-};
-
-&lt {
-	quick-tap-ms = <150>;
 };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -60,5 +60,5 @@
 };
 
 &lt {
-    quick_tap_ms = <150>;
+    quick-tap-ms = <150>;
 }

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -10,11 +10,7 @@
 #include <dt-bindings/zmk/ext_power.h>
 
 &mt {
-	tapping-term-ms = <500>;
-};
-
-&lt {
-	quick-tap-ms = <400>;
+	flavor = "tap-preferred";;
 };
 
 / {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -13,6 +13,10 @@
 	flavor = "tap-preferred";
 };
 
+&lt {
+	quick-tap-ms = <300>;
+};
+
 / {
 	keymap {
 		compatible = "zmk,keymap";

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -10,7 +10,7 @@
 #include <dt-bindings/zmk/ext_power.h>
 
 &mt {
-	flavor = "tap-preferred";;
+	flavor = "tap-preferred";
 };
 
 / {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -56,9 +56,9 @@
 };
 
 &mt {
-    tapping-term-ms = <400>;
+	tapping-term-ms = <400>;
 };
 
 &lt {
-    quick-tap-ms = <150>;
-}
+	quick-tap-ms = <150>;
+};

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -10,14 +10,6 @@
 #include <dt-bindings/zmk/ext_power.h>
 
 / {
-    &mt {
-        tapping-term-ms = <400>;
-    };
-
-    &lt {
-        quick_tap_ms = <150>;
-    }
-
 	keymap {
 		compatible = "zmk,keymap";
 
@@ -62,3 +54,11 @@
          };
 	};
 };
+
+&mt {
+    tapping-term-ms = <400>;
+};
+
+&lt {
+    quick_tap_ms = <150>;
+}

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -10,11 +10,11 @@
 #include <dt-bindings/zmk/ext_power.h>
 
 &mt {
-	tapping-term-ms = <400>;
+	tapping-term-ms = <500>;
 };
 
 &lt {
-	quick-tap-ms = <150>;
+	quick-tap-ms = <400>;
 };
 
 / {


### PR DESCRIPTION
Does this parse and override them properly now?
Was accidentally hitting Ctrl instead of space while typing, hope tap-preferred will fix it